### PR TITLE
Notifications are now triggered after all files are processed

### DIFF
--- a/src-tauri/src/thing_api.rs
+++ b/src-tauri/src/thing_api.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-
-use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_store::StoreExt;
 
 /// Sends a POST request to the WoWthing API with the provided form data and returns the response.
@@ -33,21 +31,9 @@ pub async fn submit_addon_data(app: tauri::AppHandle, contents: &str) -> Result<
     match response.status() {
         reqwest::StatusCode::OK => match response.text().await {
             Ok(text) => {
-                app.notification()
-                    .builder()
-                    .title("Wowthing Sync")
-                    .body("Upload was completed succesfully")
-                    .show()
-                    .unwrap();
                 Ok(format!("Sync completed: {:?}", text))
             }
             Err(_) => {
-                app.notification()
-                    .builder()
-                    .title("Wowthing Sync")
-                    .body("An error occurred while uploading. Please try again later.")
-                    .show()
-                    .unwrap();
                 Err(format!("There was an issue reading the response."))
             }
         },

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -1,0 +1,20 @@
+import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
+
+export const useNotifications = () => {
+  const send = async (options) => {
+    let permissionGranted = await isPermissionGranted();
+
+    if (!permissionGranted) {
+      const permission = await requestPermission();
+      permissionGranted = permission === 'granted';
+    }
+
+    if (permissionGranted) {
+      sendNotification(options);
+    }
+  };
+
+  return {
+    send
+  }
+}


### PR DESCRIPTION
- Notifications are now delivered after all uploads have finished processing
- Identified an issue where all uploads may not always process for multi-account users
- Prevented multiple uploads from processing if one file fails

Addresses #16 